### PR TITLE
Add frequency selector dropdown and reusable components

### DIFF
--- a/src/components/FrequencySelector.tsx
+++ b/src/components/FrequencySelector.tsx
@@ -1,0 +1,40 @@
+import { Form } from "react-bootstrap";
+
+export type Frequency = "daily" | "weekly" | "monthly" | "custom";
+
+interface FrequencySelectorProps {
+  value: Frequency;
+  customDate?: string;
+  onChange: (value: Frequency) => void;
+  onCustomDateChange?: (value: string) => void;
+}
+
+export default function FrequencySelector({
+  value,
+  customDate,
+  onChange,
+  onCustomDateChange,
+}: FrequencySelectorProps) {
+  return (
+    <Form.Group className="d-flex align-items-center">
+      <Form.Select
+        aria-label="Select frequency"
+        value={value}
+        onChange={(e) => onChange(e.target.value as Frequency)}
+        className="me-2"
+      >
+        <option value="daily">Daily</option>
+        <option value="weekly">Weekly</option>
+        <option value="monthly">Monthly</option>
+        <option value="custom">Custom</option>
+      </Form.Select>
+      {value === "custom" && onCustomDateChange && (
+        <Form.Control
+          type="date"
+          value={customDate}
+          onChange={(e) => onCustomDateChange(e.target.value)}
+        />
+      )}
+    </Form.Group>
+  );
+}

--- a/src/components/RepoCard.tsx
+++ b/src/components/RepoCard.tsx
@@ -1,0 +1,30 @@
+import { Card } from "react-bootstrap";
+import type { Repo } from "./types";
+
+interface RepoCardProps {
+  repo: Repo;
+}
+
+export default function RepoCard({ repo }: RepoCardProps) {
+  return (
+    <Card className="h-100">
+      <Card.Body>
+        <Card.Title>
+          <a href={repo.html_url} target="_blank" rel="noopener noreferrer">
+            {repo.name}
+          </a>
+        </Card.Title>
+        <Card.Subtitle className="mb-2 text-muted">
+          {repo.owner.login}
+        </Card.Subtitle>
+        <Card.Text>{repo.description}</Card.Text>
+      </Card.Body>
+      <Card.Footer>
+        <small className="text-body-secondary">
+          <i className="bi bi-star-fill me-1"></i>
+          {repo.stargazers_count}
+        </small>
+      </Card.Footer>
+    </Card>
+  );
+}

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -1,0 +1,8 @@
+export interface Repo {
+  id: number;
+  name: string;
+  html_url: string;
+  description: string;
+  stargazers_count: number;
+  owner: { login: string };
+}


### PR DESCRIPTION
## Summary
- add FrequencySelector reusable component for selecting daily/weekly/monthly/custom
- add RepoCard component and shared Repo type
- update page.tsx to use new components and fetch based on selected frequency

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6847e8463e6c83318396582ae66b7476