### PR TITLE
Add search functionality with custom hook

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,16 +1,18 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { Button, Col, Row } from "react-bootstrap";
+import { Button, Col, Row, Form } from "react-bootstrap";
 import RepoCard from "@/components/RepoCard";
 import FrequencySelector, { Frequency } from "@/components/FrequencySelector";
 import type { Repo } from "@/components/types";
+import useRepoSearch from "@/hooks/useRepoSearch";
 
 export default function Home() {
   const [repos, setRepos] = useState<Repo[]>([]);
   const [loading, setLoading] = useState(false);
   const [frequency, setFrequency] = useState<Frequency>("weekly");
   const [customDate, setCustomDate] = useState("");
+  const { query, setQuery, filteredRepos } = useRepoSearch(repos);
 
   const getDate = useCallback((): string => {
     const now = new Date();
@@ -62,17 +64,25 @@ export default function Home() {
       <div className="d-flex justify-content-between align-items-center mb-3">
         <h1 className="h3 m-0">Trending Repositories</h1>
         <div className="d-flex">
-          <FrequencySelector
-            value={frequency}
-            customDate={customDate}
-            onChange={setFrequency}
-            onCustomDateChange={setCustomDate}
+          <Form.Control
+            type="search"
+            placeholder="Search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            className="me-2"
           />
+          <div className="me-2">
+            <FrequencySelector
+              value={frequency}
+              customDate={customDate}
+              onChange={setFrequency}
+              onCustomDateChange={setCustomDate}
+            />
+          </div>
           <Button
             variant="dark"
             onClick={loadRepos}
             disabled={loading}
-            className="ms-2"
           >
             {loading ? "Loading..." : "Refresh"}
           </Button>
@@ -81,7 +91,7 @@ export default function Home() {
 
       {/* Use card group so all cards share equal height */}
       <Row xs={1} md={2} lg={3} className="g-4 card-group">
-        {repos.map((repo) => (
+        {filteredRepos.map((repo) => (
           <Col key={repo.id}>
             <RepoCard repo={repo} />
           </Col>

--- a/src/hooks/useRepoSearch.ts
+++ b/src/hooks/useRepoSearch.ts
@@ -1,0 +1,22 @@
+import { useState, useMemo } from "react";
+import type { Repo } from "@/components/types";
+
+export default function useRepoSearch(repos: Repo[]) {
+  const [query, setQuery] = useState("");
+
+  const filteredRepos = useMemo(() => {
+    if (!query.trim()) {
+      return repos;
+    }
+    const lower = query.toLowerCase();
+    return repos.filter((repo) => {
+      return (
+        repo.name.toLowerCase().includes(lower) ||
+        repo.owner.login.toLowerCase().includes(lower) ||
+        (repo.description ?? "").toLowerCase().includes(lower)
+      );
+    });
+  }, [repos, query]);
+
+  return { query, setQuery, filteredRepos };
+}


### PR DESCRIPTION
## Summary
- create `useRepoSearch` hook to manage query state and filter repositories
- integrate search box in the homepage using the new hook
- filter displayed repositories based on search input

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684a8f2fcf208331909d685a28f368a7