### PR TITLE
Add search filter for repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ First, run the development server:
 npm run dev
 ```
 
-The development server runs at [http://localhost:3000](http://localhost:3000). The home page shows the 15 most starred repositories created in the last week. Click **Refresh** to get the latest data.
+The development server runs at [http://localhost:3000](http://localhost:3000). The home page shows the 15 most starred repositories created in the last week. Click **Refresh** to get the latest data. Use the search box to filter repositories by name or owner.
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,16 +1,19 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { Button, Col, Row } from "react-bootstrap";
+import { Button, Col, Form, Row } from "react-bootstrap";
 import RepoCard from "@/components/RepoCard";
 import FrequencySelector, { Frequency } from "@/components/FrequencySelector";
 import type { Repo } from "@/components/types";
+import useRepoSearch from "@/hooks/useRepoSearch";
 
 export default function Home() {
   const [repos, setRepos] = useState<Repo[]>([]);
   const [loading, setLoading] = useState(false);
   const [frequency, setFrequency] = useState<Frequency>("weekly");
   const [customDate, setCustomDate] = useState("");
+
+  const { query, setQuery, filteredRepos } = useRepoSearch(repos);
 
   const getDate = useCallback((): string => {
     const now = new Date();
@@ -79,9 +82,20 @@ export default function Home() {
         </div>
       </div>
 
+      <Row className="mb-3">
+        <Col>
+          <Form.Control
+            type="text"
+            placeholder="Search repositories..."
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+          />
+        </Col>
+      </Row>
+
       {/* Use card group so all cards share equal height */}
       <Row xs={1} md={2} lg={3} className="g-4 card-group">
-        {repos.map((repo) => (
+        {filteredRepos.map((repo) => (
           <Col key={repo.id}>
             <RepoCard repo={repo} />
           </Col>

--- a/src/hooks/useRepoSearch.ts
+++ b/src/hooks/useRepoSearch.ts
@@ -1,0 +1,18 @@
+import { useMemo, useState } from "react";
+import type { Repo } from "@/components/types";
+
+export default function useRepoSearch(repos: Repo[]) {
+  const [query, setQuery] = useState("");
+
+  const filteredRepos = useMemo(() => {
+    if (!query) return repos;
+    const lower = query.toLowerCase();
+    return repos.filter(
+      (r) =>
+        r.name.toLowerCase().includes(lower) ||
+        r.owner.login.toLowerCase().includes(lower)
+    );
+  }, [query, repos]);
+
+  return { query, setQuery, filteredRepos };
+}


### PR DESCRIPTION
## Summary
- allow searching/filtering of repositories
- provide `useRepoSearch` hook
- document search usage in README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684aab0ebd0883319da8c92cc3876d23