### PR TITLE
Add search filtering for trending repos

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,16 +1,18 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { Button, Col, Row } from "react-bootstrap";
+import { Button, Col, Row, Form } from "react-bootstrap";
 import RepoCard from "@/components/RepoCard";
 import FrequencySelector, { Frequency } from "@/components/FrequencySelector";
 import type { Repo } from "@/components/types";
+import useSearch from "@/hooks/useSearch";
 
 export default function Home() {
   const [repos, setRepos] = useState<Repo[]>([]);
   const [loading, setLoading] = useState(false);
   const [frequency, setFrequency] = useState<Frequency>("weekly");
   const [customDate, setCustomDate] = useState("");
+  const { query, setQuery, filtered } = useSearch(repos);
 
   const getDate = useCallback((): string => {
     const now = new Date();
@@ -79,9 +81,20 @@ export default function Home() {
         </div>
       </div>
 
+      <Row className="mb-3">
+        <Col>
+          <Form.Control
+            type="search"
+            placeholder="Search repositories"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+          />
+        </Col>
+      </Row>
+
       {/* Use card group so all cards share equal height */}
       <Row xs={1} md={2} lg={3} className="g-4 card-group">
-        {repos.map((repo) => (
+        {filtered.map((repo) => (
           <Col key={repo.id}>
             <RepoCard repo={repo} />
           </Col>

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -1,0 +1,18 @@
+import { useState, useMemo } from "react";
+import type { Repo } from "@/components/types";
+
+export default function useSearch(repos: Repo[]) {
+  const [query, setQuery] = useState("");
+
+  const filtered = useMemo(() => {
+    if (!query.trim()) return repos;
+    const lower = query.toLowerCase();
+    return repos.filter(
+      (r) =>
+        r.name.toLowerCase().includes(lower) ||
+        r.description?.toLowerCase().includes(lower)
+    );
+  }, [query, repos]);
+
+  return { query, setQuery, filtered };
+}


### PR DESCRIPTION
## Summary
- add a custom `useSearch` hook for filtering repositories by a query
- integrate search hook into `page.tsx`
- display a new search box row and render filtered results

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684aada5b6dc83319ddd174ffecf7d06